### PR TITLE
remove /r/ path for devise actions

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,12 +3,11 @@ Rails.application.routes.draw do
   resources :accounts
   root to: 'landing#new'
 
-  post "nuevo", to: "landing#create", as: :form_account_users
-  get  "creado", to: "landing#success", as: :landing_success
-  get  "/:email", to: "landing#show", as: :landing_show
+  post 'nuevo', to: 'landing#create', as: :form_account_users
+  get  'creado', to: 'landing#success', as: :landing_success
 
   # Devise
-  devise_for :users, path: 'r', path_names: {
+  devise_for :users, path: '', path_names: {
     sign_in: 'login',
     sign_out: 'logout',
     password: 'secret',
@@ -17,4 +16,6 @@ Rails.application.routes.draw do
     registration: 'register',
     sign_up: 'cmon_let_me_in'
   }, controllers: { confirmations: 'confirmation' }
+
+  get '/:email', to: 'landing#show', as: :landing_show
 end


### PR DESCRIPTION
Cambiar el orden en routes permite verificar primero si es una ruta de devise antes de tomar el path como email