### PR TITLE
fix(landing): show info even if mail contains dots

### DIFF
--- a/app/controllers/landing_controller.rb
+++ b/app/controllers/landing_controller.rb
@@ -19,7 +19,10 @@ class LandingController < ApplicationController
   end
 
   def show
-    @resource = User.find_by(email: "#{params[:email]}.#{params[:format]}")
+    is_email = Devise::email_regexp =~ params[:email]
+    raise ActionController::RoutingError.new('Not found') unless is_email
+
+    @resource = User.find_by(email: params[:email])
     raise ActionController::RoutingError.new('Not found') if @resource&.confirmed_at.nil?
     @resource
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,5 +18,5 @@ Rails.application.routes.draw do
     sign_up: 'cmon_let_me_in'
   }, controllers: { confirmations: 'confirmation' }
 
-  get '/:email', to: 'landing#show', as: :landing_show
+  get '*email', to: 'landing#show', as: :landing_show, format: false
 end


### PR DESCRIPTION
Con el código como estaba no podía ver mi mail (de la forma foo.bar@example.com). Con este cambio deberiamos andar bien!