### PR TITLE
Arreglar botón que no carga ícono font-awesome

### DIFF
--- a/app/views/landing/_form.html.erb
+++ b/app/views/landing/_form.html.erb
@@ -30,6 +30,6 @@
   </div>
 
   <div>
-    <button class="btn btn-primary"><i class="fa fa-floppy-o"></i> Guardar</button>
+    <button class="btn btn-primary center-block">Crear mi num</button>
   </div>
 <% end %>


### PR DESCRIPTION
# Cambios
Ni idea cómo arreglar font-awesome, por lo que para sacar una solución rápida borré el ícono.